### PR TITLE
Fix verify plural method

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,9 @@ dicio = Dicio()
 
 
 def gerar_frase(palavra_escolhida, verbo_escolhido):
+    if not palavra_escolhida.isalpha() or not verbo_escolhido.isalpha():
+        raise Exception
+
     resultado_dicio = dicio.search(palavra_escolhida)
 
     genero = verifica_genero(palavra_escolhida, resultado_dicio)
@@ -87,9 +90,12 @@ def main(count, saida, verbos, palavras):
         palavra_escolhida = escolher_palavra(palavras)
         print('Palavra escolhida --> ' + palavra_escolhida + '\n')
 
-        frase = gerar_frase(palavra_escolhida, verbo_escolhido)
-        print('Frase  --> ' + frase + '\n')
-        frases_geradas.append(frase)
+        try:
+            frase = gerar_frase(palavra_escolhida, verbo_escolhido)
+            print('Frase  --> ' + frase + '\n')
+            frases_geradas.append(frase)
+        except Exception:
+            print('Não é possível gerar a frase')
 
     if not os.path.exists(os.path.dirname(saida)):
         diretorio_para_criar = os.path.dirname(saida)

--- a/test/test.py
+++ b/test/test.py
@@ -1,0 +1,16 @@
+import unittest
+import main
+
+class TestMain(unittest.TestCase):
+
+    def setUp(self):
+        self.palavra = "JURA"
+        self.verbo = "clinicar"
+
+    def test_gerar_frase_com_palavra_alnum(self):
+        self.palavra_alnum = self.palavra + "0"
+        self.assertRaises(Exception, main.gerar_frase(self.palavra, self.verbo))
+
+    def test_gerar_frase_com_palavra(self):
+        frase_esperada = "clinicar a JURA"
+        self.assertEqual(frase_esperada, main.gerar_frase(self.palavra, self.verbo))


### PR DESCRIPTION
Resolve #15 

**Qual era o problema?**
Método de verificar se a palavra é plural estava gerando um erro de NoneType.

**O que foi descoberto?**
Na classe Dicio, era retornado None caso a palavra contesse caracteres númericos, por isso no método verificar se a palavra é plural gerava uma exceção de NoneType, pois o resultado de `dicio.search()` retornava None.

**O que foi feito?**
Foi adicionado uma verificação, e caso a palavra esteja inválida gera uma exceção e não forma a frase.

**Testes**
Testes foram adicionados para os dois casos, palavra inválida e palavra válida.
